### PR TITLE
move signal registration/de-registration to decorator scope

### DIFF
--- a/contexttimer/timeout.py
+++ b/contexttimer/timeout.py
@@ -34,8 +34,6 @@ class Timeout(Exception):
 def timeout_handler(signum, frame):
     raise Timeout
 
-signal.signal(signal.SIGALRM, timeout_handler)
-
 
 def timeout(limit, handler):
     """A decorator ensuring that the decorated function tun time does not
@@ -65,6 +63,8 @@ def timeout(limit, handler):
     """
     def wrapper(f):
         def wrapped_f(*args, **kwargs):
+            old_handler = signal.getsignal(signal.SIGALRM)
+            signal.signal(signal.SIGALRM, timeout_handler)
             signal.alarm(limit)
             try:
                 res = f(*args, **kwargs)
@@ -73,6 +73,7 @@ def timeout(limit, handler):
             else:
                 return res
             finally:
+                signal.signal(signal.SIGALRM, old_handler)
                 signal.alarm(0)
         return wrapped_f
     return wrapper


### PR DESCRIPTION
Currently importing `contexttimer.timeout` will register a signal handler for `signal.SIGALRM`, blowing away any previously registered signal handlers for `SIGALRM`. Registering in decorator scope, and de-registering it in the finally block removes this import side-effect, and protects `@timeout` calls from similar side-effects should another package choose to register a `SIGALRM` handler after `contexttimer.timeout` is imported.
