### PR TITLE
Added optional printing functionality

### DIFF
--- a/contexttimer/__init__.py
+++ b/contexttimer/__init__.py
@@ -40,11 +40,21 @@ class Timer(object):
     On Unix systems, it corresponds to time.time.
     On Windows systems, it corresponds to time.clock.
 
+    Keyword arguments:
+        output -- if True, print output after exiting context.
+                  if callable, pass output to callable.
+        format -- str.format string to be used for output; default "took {} seconds"
+        prefix -- string to prepend (plus a space) to output
+                  For convenience, if you only specify this, output defaults to True.
     """
 
-    def __init__(self, timer=default_timer, factor=1):
+    def __init__(self, timer=default_timer, factor=1,
+                 output=None, fmt="took {:.3f} seconds", prefix=""):
         self.timer = timer
         self.factor = factor
+        self.output = output
+        self.fmt = fmt
+        self.prefix = prefix
         self.end = None
 
     def __call__(self):
@@ -59,6 +69,16 @@ class Timer(object):
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """ Set the end time """
         self.end = self()
+
+        if self.prefix and self.output is None:
+            self.output = True
+
+        if self.output:
+            output = " ".join([self.prefix, self.fmt.format(self.elapsed)])
+            if callable(self.output):
+                self.output(output)
+            else:
+                print output
 
     def __str__(self):
         return '%.3f' % (self.elapsed)

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,0 +1,29 @@
+import contexttimer
+import unittest
+import mock
+from cStringIO import StringIO
+
+
+class ContextTimerTest(unittest.TestCase):
+    def test_timer_print(self):
+        def print_reversed(string):
+            print " ".join(reversed(string.split()))
+
+        tests = [
+            # (kwargs, expected_regex)
+            ({'output': True}, r"took [0-9.]+ seconds"),
+            ({'output': print_reversed}, r"seconds [0-9.]+ took"),
+
+            ({'prefix': 'foo'}, r"foo took [0-9.]+ seconds"),
+            ({'output': True, 'prefix': 'foo'}, r"foo took [0-9.]+ seconds"),
+            ({'output': True, 'fmt': '{} seconds later...'}, r"[0-9.]+ seconds later..."),
+        ]
+
+        for kwargs, expected in tests:
+            output = StringIO()
+            with mock.patch('sys.stdout', new=output):
+                with contexttimer.Timer(**kwargs):
+                    pass
+
+            self.assertIsNotNone(output)
+            self.assertRegexpMatches(output.getvalue(), expected)


### PR DESCRIPTION
Timer() now accepts three new keyword arguments:

    output -- if True, print output after exiting context.
              if callable, pass output to callable.
    format -- str.format string to be used for output;
              default "took {} seconds"
    prefix -- string to prepend (plus a space) to output
              For convenience, if you only specify this,
              output defaults to True.

Also added unit test.

Thanks for releasing this; it's very similar to things I've probably written and thrown away or forgotten about many times.