### PR TITLE
Add more control over logging for timer decorator

### DIFF
--- a/contexttimer/__init__.py
+++ b/contexttimer/__init__.py
@@ -105,7 +105,9 @@ class Timer(object):
             return (self.end - self.start) * self.factor
 
 
-def timer(logger=None, level=logging.INFO, *func_or_func_args, **timer_kwargs):
+def timer(logger=None, level=logging.INFO,
+          fmt="function %(function_name)s execution time: %(execution_time).3f",
+          *func_or_func_args, **timer_kwargs):
     """ Function decorator displaying the function execution time
 
     All kwargs are the arguments taken by the Timer class constructor.
@@ -126,9 +128,7 @@ def timer(logger=None, level=logging.INFO, *func_or_func_args, **timer_kwargs):
                 }
                 logger.log(
                     level,
-                    "function %s execution time: %.3f",
-                    f.__name__,
-                    t.elapsed,
+                    fmt % extra,
                     extra=extra)
             else:
                 print("function %s execution time: %.3f " %

--- a/contexttimer/__init__.py
+++ b/contexttimer/__init__.py
@@ -25,6 +25,7 @@ __version__ = '0.3.1'
 
 import functools
 import collections
+import logging
 
 from timeit import default_timer
 
@@ -84,7 +85,7 @@ class Timer(object):
             return (self.end - self.start) * self.factor
 
 
-def timer(logger=None, *func_or_func_args, **timer_kwargs):
+def timer(logger=None, level=logging.INFO, *func_or_func_args, **timer_kwargs):
     """ Function decorator displaying the function execution time
 
     All kwargs are the arguments taken by the Timer class constructor.
@@ -99,8 +100,16 @@ def timer(logger=None, *func_or_func_args, **timer_kwargs):
             with Timer(**timer_kwargs) as t:
                 out = f(*args, **kwargs)
             if logger:
-                logger.debug(
-                    "function %s execution time: %.3f", f.__name__, t.elapsed)
+                extra = {
+                    'function_name': f.__name__,
+                    'execution_time': t.elapsed,
+                }
+                logger.log(
+                    level,
+                    "function %s execution time: %.3f",
+                    f.__name__,
+                    t.elapsed,
+                    extra=extra)
             else:
                 print("function %s execution time: %.3f " %
                       (f.__name__, t.elapsed))


### PR DESCRIPTION
* Use patch from @tuky to allow control over log level and to include context in log
* Allow user to provide a custom format string for the log message

@tuky -- I saw that you had already done one of the things I needed so I forked your fork and then added the other bit that I wanted.

@brouberol thanks for this package, it's quite handy!