### PR TITLE
Fix decorator so that fmt works when without logging.

### DIFF
--- a/contexttimer/__init__.py
+++ b/contexttimer/__init__.py
@@ -121,18 +121,17 @@ def timer(logger=None, level=logging.INFO,
         def wrapped(*args, **kwargs):
             with Timer(**timer_kwargs) as t:
                 out = f(*args, **kwargs)
+            context = {
+                'function_name': f.__name__,
+                'execution_time': t.elapsed,
+            }
             if logger:
-                extra = {
-                    'function_name': f.__name__,
-                    'execution_time': t.elapsed,
-                }
                 logger.log(
                     level,
-                    fmt % extra,
-                    extra=extra)
+                    fmt % context,
+                    extra=context)
             else:
-                print("function %s execution time: %.3f " %
-                      (f.__name__, t.elapsed))
+                print(fmt % context)
             return out
         return wrapped
     if (len(func_or_func_args) == 1

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -27,3 +27,21 @@ class ContextTimerTest(unittest.TestCase):
 
             self.assertIsNotNone(output)
             self.assertRegexpMatches(output.getvalue(), expected)
+
+    def test_decorator_print(self):
+        tests = [
+            ({}, r"function foo execution time: [0-9.]+"),
+            ({'fmt': '%(execution_time)s seconds later...'}, r"[0-9.]+ seconds later..."),
+        ]
+
+
+        for kwargs, expected in tests:
+            output = StringIO()
+            with mock.patch('sys.stdout', new=output):
+                @contexttimer.timer(**kwargs)
+                def foo():
+                    pass
+                foo()
+
+            self.assertIsNotNone(output)
+            self.assertRegexpMatches(output.getvalue(), expected)


### PR DESCRIPTION
Make the effect of the fmt argument to the decorator consistent with
or without logging.

Added a test for this as well.

Ooops, I missed this the first time around.